### PR TITLE
Config: gemfile_addition was missing foreman gem

### DIFF
--- a/doc/gemfile_addition.txt
+++ b/doc/gemfile_addition.txt
@@ -17,6 +17,7 @@
   gem 'web-app-theme', :git => 'git://github.com/dsaronin/web-app-theme.git'
   gem 'devise', '~>3.2'
   gem 'milia', :git => 'git://github.com/dsaronin/milia.git', :branch => 'v1.0.0-beta-7'
+  gem 'foreman'
 
   # airbrake is optional and configured by config.use_airbrake in milia initializer
   # default is false; if you change it to true, uncomment out the line below


### PR DESCRIPTION
Issue: 
- The sample web app guide asks the user to do foreman start but the foreman gem is missing in the Gemfile

Fix:
- Add foreman to the gemfile_addition which means it will be in the Gemfile if user is following instructions
