### PR TITLE
Remove deprecated method before_filter 

### DIFF
--- a/lib/generators/milia/templates/devise_permitted_parameters.rb
+++ b/lib/generators/milia/templates/devise_permitted_parameters.rb
@@ -2,7 +2,7 @@ module DevisePermittedParameters
 	extend ActiveSupport::Concern
 
 	included do
-		before_filter :configure_permitted_parameters
+		before_action :configure_permitted_parameters
 	end
 
 	protected


### PR DESCRIPTION
Updated the `DevisePermittedParameters` template and changed the deprecated method `before_filter` to `before_action`.